### PR TITLE
Update markdown.app.src to current version number

### DIFF
--- a/src/markdown.app.src
+++ b/src/markdown.app.src
@@ -1,4 +1,4 @@
 {application, markdown,
  [{description, "An implementation of markdown written in Erlang"},
-  {vsn, "0.1.0"},
+  {vsn, "1.1.12"},
   {applications, [kernel, stdlib]}]}.


### PR DESCRIPTION
Readme.md states that the current version has the number 1.1.12 – reflect that in markdown.app.src.
